### PR TITLE
fix: sync sender progress bar with actual data delivery

### DIFF
--- a/src/lib/FileTransferApp.ts
+++ b/src/lib/FileTransferApp.ts
@@ -79,6 +79,8 @@ export class FileTransferApp {
         });
 
         this.peerManager.on("peerdisconnected", (peerId: string) => {
+            this.peerManager.getSender().stop();
+            
             this.peerEvents.emit("peerdisconnected", peerId);
         });
 
@@ -87,6 +89,8 @@ export class FileTransferApp {
         });
 
         this.peerManager.on("datachannelclose", (peerId: string) => {
+            this.peerManager.getSender().stop();
+            
             this.peerEvents.emit("datachannelclose", peerId);
         });
     }

--- a/src/lib/components/FileTransfer.svelte
+++ b/src/lib/components/FileTransfer.svelte
@@ -11,10 +11,10 @@
     let transferIsStarted = $state(false);
     let shareUrl = $state("");
     let notification = $state("");
+    let isError = $state(false);
     let filesCount = $state(0);
     let totalSize = $state(0);
     let sendProgress = $state(0);
-    let isCompleted = $state(false);
     let fileList: FileList | null = $state(null);
 
     const url = getSignalingURL();
@@ -49,7 +49,6 @@
         totalSize = 0;
         transferIsStarted = false;
         sendProgress = 0;
-        isCompleted = false;
         fileList = null;
     }
 
@@ -96,7 +95,14 @@
             await fileTransferApp.sendFile(peerId, file);
         }
 
-        isCompleted = true;
+        await fileTransferApp.disconnect();
+    })
+
+    fileTransferApp.senderEvents.on("onerror", async (peerId, error) => {
+        resetFileSelections();
+
+        isError = true;
+        notification = error;
     })
 
     $effect(() => {
@@ -117,7 +123,7 @@
 {#if notification}
     <Toast
         notifacation={notification}
-        notificationType={"success"}
+        notificationType={(isError) ? "error" : "success"}
     />
 {/if}
 

--- a/src/lib/webrtc/transfer/ISender.ts
+++ b/src/lib/webrtc/transfer/ISender.ts
@@ -5,4 +5,5 @@ export interface ISender extends EventEmitter<SenderEvents> {
     send(dataChannel: RTCDataChannel, peerId: string, data: any): Promise<void>;
     pause(): void;
     resume(): void;
+    stop(): void;
 }


### PR DESCRIPTION
### Problem

The sender's progress bar was reaching 100% as soon as all chunks were read and queued for sending, even if they were still buffered and not yet delivered to the receiver. This caused a mismatch, especially over slower connections.

### Solution

Implemented a buffer-aware sending strategy. Now the sender waits for the `bufferedAmount` to drop below a threshold before proceeding, ensuring that data is not just read but also actively delivered. The progress bar reflects actual transmission rather than just local read progress.

Closes #2 
